### PR TITLE
Fixes #17, Static Body entities not updating x/y

### DIFF
--- a/box2d.js
+++ b/box2d.js
@@ -379,13 +379,18 @@ Crafty.extend({
 				for(var b = _world.GetBodyList(); b; b=b.GetNext()) {
 					if (b.GetUserData()) {
 						var sprite = b.GetUserData();
-						sprite.attr(
+						if(b.GetType() !== 0){ // Non-static bodies update their x/y from the physics step
+							sprite.attr(
 									{
 										x: b.GetPosition().x * _PTM_RATIO,
 										y:b.GetPosition().y * _PTM_RATIO
 									}
 							);
-						sprite.rotation = Crafty.math.radToDeg(b.GetAngle());
+							sprite.rotation = Crafty.math.radToDeg(b.GetAngle());
+						} else { // Static bodies can be updated via sprite.x and sprite.y, which should flow back into the physics simulation.
+							b.SetPosition({ x: sprite.x / _PTM_RATIO, y: sprite.y / _PTM_RATIO });
+						}
+						
 
 					}
 				}

--- a/box2d.js
+++ b/box2d.js
@@ -379,13 +379,18 @@ Crafty.extend({
 				for(var b = _world.GetBodyList(); b; b=b.GetNext()) {
 					if (b.GetUserData()) {
 						var sprite = b.GetUserData();
-						sprite.attr(
+						if(b.GetType !== 0){ // Non-static bodies update their x/y from the physics step
+							sprite.attr(
 									{
 										x: b.GetPosition().x * _PTM_RATIO,
 										y:b.GetPosition().y * _PTM_RATIO
 									}
 							);
-						sprite.rotation = Crafty.math.radToDeg(b.GetAngle());
+							sprite.rotation = Crafty.math.radToDeg(b.GetAngle());
+						} else { // Static bodies can be updated via sprite.x and sprite.y, which should flow back into the physics simulation.
+							b.SetPosition({ x: sprite.x / _PTM_RATIO, y: sprite.y / _PTM_RATIO });
+						}
+						
 
 					}
 				}


### PR DESCRIPTION
This fixes #17, which is x and y coordinates being set on entities with
the 2D component that have static bodiesf not flowing through to the
physics simulation. When setting x/y for a static body the most natural
way to do it is through entity.x / entity.y instead of stepping down into
box2d code to say entity.body.SetPosition({ x, y }) and knowing about PTM
ratio, etc.
