### PR TITLE
Fixes #22, physics timestep issue

### DIFF
--- a/box2d.js
+++ b/box2d.js
@@ -369,9 +369,9 @@ Crafty.extend({
 
 			_world.SetContactListener(contactListener);
 
-			Crafty.bind("EnterFrame", function() {
+			Crafty.bind("EnterFrame", function(frameInfo) {
 				_world.Step(
-					   1 / 30   //frame-rate
+					   frameInfo / 1000   //frame-rate
 					,  8       //velocity iterations
 					,  3       //position iterations
 				 );


### PR DESCRIPTION
This commit changes the behavior of the physics time step to be equal to
the time it took to render the last frame. This will give more consistent
motion across frames.